### PR TITLE
Update go.mod to use it as external module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module ubiq-fpe-go
+module github.com/ubiqsecurity/ubiq-fpe-go
 
 go 1.17


### PR DESCRIPTION
Changing go.mod using public github URL to be able to use it as external package .